### PR TITLE
Add support for h9_start()

### DIFF
--- a/r/NAMESPACE
+++ b/r/NAMESPACE
@@ -3,3 +3,4 @@
 export(h9_get)
 export(h9_node)
 export(h9_set)
+export(h9_start)

--- a/r/R/hal9.R
+++ b/r/R/hal9.R
@@ -112,3 +112,15 @@ h9_start_api_server <- function(script_dir, port) {
         plumber::pr_post("/eval", function(manifest) hal9:::process_request(manifest)) |>
         plumber::pr_run(port = port)
 }
+
+#' @export
+h9_start <- function(server = system.file("demo-user-script.R", package = "hal9"), port = 6806) {
+    user_code <- readLines(server)
+    server_code <- readLines(system.file("demo-server-spec.R", package = "hal9"))
+
+    api_file <- tempfile()
+    writeLines(c(user_code, server_code), api_file)
+
+    pb <- plumber::plumb("./inst/demo-server-spec.R")
+    plumber::pr_run(pb, port = port)
+}


### PR DESCRIPTION
In order to create and test some examples under say `/examples/controls-basics` we need a way to start the server in that folder with a custom `.R` or `.py` file, so adding `h9_start()` for this. It takes an optional `server` parameter with the server file to use.