### PR TITLE
Add support for h9_reset() to reset environment

### DIFF
--- a/examples/dropdown-table/app.json
+++ b/examples/dropdown-table/app.json
@@ -60,7 +60,7 @@
     "11100": {}
   },
   "scripts": {
-    "11099": "<!--\n  input: []\n  params:\n    - name: values\n      label: Values\n      value:\n        - control: textbox\n          value: versicolor,setosa,virginica\n  output: [ dropdown, html ]\n  interactive: true\n  layout:\n    - width: inner\n-->\n\n<script src=\"https://cdn.jsdelivr.net/npm/vue@2\"></script>\n<link rel=\"stylesheet\" href=\"https://unpkg.com/buefy/dist/buefy.min.css\">\n<script src=\"https://unpkg.com/buefy/dist/buefy.min.js\"></script>\n\n<div class=\"control\">\n  <template>\n    <section>\n      <b-select v-model=\"value\">\n        <option v-for=\"o in options\" :value='o'>\n          {{ o }}\n        </option>\n      </b-select>\n    </section>\n  </template>\n</div>\n\n<script>\n  values = typeof(values) === 'object' ? values : values.split(',');\n  var dropdown = hal9.getState({ dropdown:  values[0] }).dropdown;\n\n  var app = new Vue({\n    el: html.getElementsByClassName('control')[0],\n    data: function() {\n      var vue = this;\n\n      if (hal9.onEvent) hal9.onEvent('onParams', function(param, values) {\n        if (param != 'values') return;\n        vue.options = typeof(values) === 'object' ? values : values.split(',');\n      })\n\n      return {\n        value: dropdown,\n        options: values\n      }\n    },\n    watch: {\n      value: function(value) {\n        if (hal9.triggerEvent) hal9.triggerEvent('on_update', value);\n        hal9.updateState('dropdown', value, true);\n      }\n    }\n  })\n\n  html.style.height = 'auto';\n</script>",
+    "11099": "<!--\n  input: []\n  params:\n    - name: values\n      label: Values\n      value:\n        - control: textbox\n          value: versicolor,setosa,virginica\n  output: [ dropdown, html ]\n  interactive: true\n  layout:\n    - width: inner\n-->\n\n<script src=\"https://cdn.jsdelivr.net/npm/vue@2\"></script>\n<link rel=\"stylesheet\" href=\"https://unpkg.com/buefy/dist/buefy.min.css\">\n<script src=\"https://unpkg.com/buefy/dist/buefy.min.js\"></script>\n\n<div class=\"control\">\n  <template>\n    <section>\n      <b-select v-model=\"value\">\n        <option v-for=\"o in options\" :value='o'>\n          {{ o }}\n        </option>\n      </b-select>\n    </section>\n  </template>\n</div>\n\n<script>\n  values = typeof(values) === 'object' ? values : values.split(',');\n  var dropdown = hal9.getState({}).dropdown;\n\n  var app = new Vue({\n    el: html.getElementsByClassName('control')[0],\n    data: function() {\n      var vue = this;\n\n      if (hal9.onEvent) hal9.onEvent('onParams', function(param, values) {\n        if (param != 'values') return;\n        vue.options = typeof(values) === 'object' ? values : values.split(',');\n      })\n\n      return {\n        value: dropdown,\n        options: values\n      }\n    },\n    watch: {\n      value: function(value) {\n        if (hal9.triggerEvent) hal9.triggerEvent('on_update', value);\n        hal9.updateState('dropdown', value, true);\n      }\n    }\n  })\n\n  html.style.height = 'auto';\n</script>",
     "11100": "/**\n  input: [ rawhtml ]\n  output: [ html ]\n  layout:\n    - width: 900px\n**/\n\nhtml.innerHTML = rawhtml;\n"
   },
   "version": "0.0.1",
@@ -68,17 +68,17 @@
     "stepLayouts": [
       {
         "stepId": 11099,
-        "width": "179px",
-        "left": "12px",
-        "height": "43px",
-        "top": "7px"
+        "width": "0px",
+        "left": "0px",
+        "height": "21px",
+        "top": "0px"
       },
       {
         "stepId": 11100,
         "width": "900px",
-        "left": "12px",
-        "height": "456px",
-        "top": "50px"
+        "left": "0px",
+        "height": "0px",
+        "top": "21px"
       }
     ]
   },

--- a/r/R/hal9.R
+++ b/r/R/hal9.R
@@ -106,8 +106,15 @@ client_html <- function(...) {
     html
 }
 
+h9_reset <- function() {
+  .globals_nodes <- new.env()
+  .globals_data <- new.env()
+}
+
 #' @export
 h9_start <- function(app = "app.R", port = 6806) {
+    h9_reset()
+
     if (!file.exists(app)) writeLines("", app)
 
     user_code <- readLines(app)
@@ -115,9 +122,13 @@ h9_start <- function(app = "app.R", port = 6806) {
 
     api_file <- tempfile()
     writeLines(c(
+        "## User Code",
         user_code,
+        "",
+        "## Hal9 Code",
         paste0("app_file <- \"", normalizePath(app), "\""),
         paste0("app_path <- \"", dirname(normalizePath(app)), "\""),
+        "",
         server_code
     ), api_file)
 

--- a/r/R/hal9.R
+++ b/r/R/hal9.R
@@ -107,8 +107,8 @@ client_html <- function(...) {
 }
 
 h9_reset <- function() {
-  .globals_nodes <- new.env()
-  .globals_data <- new.env()
+  rm(list = ls(envir = .globals_nodes), envir = .globals_nodes)
+  rm(list = ls(envir = .globals_data), envir = .globals_data)
 }
 
 #' @export


### PR DESCRIPTION
Currently, if we run `hal9_start()` with an app and run it again, the state is incorrect since we are left with the state of the previous app which might show the wrong data for a control selections, etc. This change resets the environment whenever we run `h9_start()`.

Will merge since this is a pretty obvious fix.