### PR TITLE
Add debug flag and start building app showcasing all controls

### DIFF
--- a/examples/control-basics/app.R
+++ b/examples/control-basics/app.R
@@ -1,1 +1,27 @@
+library(hal9)
 
+iris |> h9_set("df")
+
+h9_node(
+  "numberinput",
+  on_update = function(value) {
+    h9_set(value, "number")
+  }
+)
+
+h9_node(
+  "dropdown",
+  on_update = function(value) {
+    h9_set(value, "dropdown")
+  }
+)
+
+h9_node(
+  "rawhtml",
+  rawhtml = function() {
+    paste0(
+      "Number (", h9_get("number"), ") <br>",
+      "Drodown (", h9_get("dropdown"), ") <br>"
+    )
+  }
+)

--- a/examples/control-basics/app.json
+++ b/examples/control-basics/app.json
@@ -134,27 +134,7 @@
   },
   "state": {
     "steps": {
-      "11099": {
-        "events": {
-          "onParams": [
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null
-          ]
-        }
-      }
+      "11099": {}
     }
   }
 }

--- a/examples/control-basics/app.json
+++ b/examples/control-basics/app.json
@@ -26,6 +26,46 @@
           "label": "Values"
         }
       }
+    },
+    {
+      "name": "numberinput",
+      "function": "number",
+      "source": "controls/number.html",
+      "language": "html",
+      "label": "Number Input",
+      "description": "Embed a number input control",
+      "icon": "fa-light fa-input-numeric",
+      "dragdrop": true,
+      "build": "true",
+      "id": 11100,
+      "params": {
+        "label": {
+          "id": 1,
+          "static": true,
+          "value": [
+            {
+              "control": "textbox",
+              "value": "Number",
+              "id": 0
+            }
+          ],
+          "name": "label",
+          "label": "Label"
+        }
+      }
+    },
+    {
+      "name": "rawhtml",
+      "function": "",
+      "source": "controls/rawhtml.js",
+      "language": "javascript",
+      "label": "HTML",
+      "description": "Enables to render arbitrary HTML from data",
+      "icon": "fa-brands fa-html5",
+      "dragdrop": true,
+      "build": "false",
+      "id": 11101,
+      "params": {}
     }
   ],
   "params": {
@@ -43,27 +83,77 @@
         "name": "values",
         "label": "Values"
       }
-    }
+    },
+    "11100": {
+      "label": {
+        "id": 1,
+        "static": true,
+        "value": [
+          {
+            "control": "textbox",
+            "value": "Number",
+            "id": 0
+          }
+        ],
+        "name": "label",
+        "label": "Label"
+      }
+    },
+    "11101": {}
   },
   "scripts": {
-    "11099": "<!--\n  input: []\n  params:\n    - name: values\n      label: Values\n      value:\n        - control: textbox\n          value: versicolor,setosa,virginica\n  output: [ dropdown, html ]\n  interactive: true\n  layout:\n    - width: inner\n-->\n\n<script src=\"https://cdn.jsdelivr.net/npm/vue@2\"></script>\n<link rel=\"stylesheet\" href=\"https://unpkg.com/buefy/dist/buefy.min.css\">\n<script src=\"https://unpkg.com/buefy/dist/buefy.min.js\"></script>\n\n<div class=\"control\">\n  <template>\n    <section>\n      <b-select v-model=\"value\">\n        <option v-for=\"o in options\" :value='o'>\n          {{ o }}\n        </option>\n      </b-select>\n    </section>\n  </template>\n</div>\n\n<script>\n  values = typeof(values) === 'object' ? values : values.split(',');\n  var dropdown = hal9.getState({ dropdown:  values[0] }).dropdown;\n\n  var app = new Vue({\n    el: html.getElementsByClassName('control')[0],\n    data: function() {\n      var vue = this;\n\n      if (hal9.onEvent) hal9.onEvent('onParams', function(param, values) {\n        if (param != 'values') return;\n        vue.options = typeof(values) === 'object' ? values : values.split(',');\n      })\n\n      return {\n        value: dropdown,\n        options: values\n      }\n    },\n    watch: {\n      value: function(value) {\n        if (hal9.triggerEvent) hal9.triggerEvent('on_update', value);\n        hal9.updateState('dropdown', value, true);\n      }\n    }\n  })\n\n  html.style.height = 'auto';\n</script>"
+    "11099": "<!--\n  input: []\n  params:\n    - name: values\n      label: Values\n      value:\n        - control: textbox\n          value: versicolor,setosa,virginica\n  output: [ dropdown, html ]\n  interactive: true\n  layout:\n    - width: inner\n-->\n\n<script src=\"https://cdn.jsdelivr.net/npm/vue@2\"></script>\n<link rel=\"stylesheet\" href=\"https://unpkg.com/buefy/dist/buefy.min.css\">\n<script src=\"https://unpkg.com/buefy/dist/buefy.min.js\"></script>\n\n<div class=\"control\">\n  <template>\n    <section>\n      <b-select v-model=\"value\">\n        <option v-for=\"o in options\" :value='o'>\n          {{ o }}\n        </option>\n      </b-select>\n    </section>\n  </template>\n</div>\n\n<script>\n  values = typeof(values) === 'object' ? values : values.split(',');\n  var dropdown = hal9.get('dropdown');\n\n  var app = new Vue({\n    el: html.getElementsByClassName('control')[0],\n    data: function() {\n      var vue = this;\n\n      hal9.onEvent('onParams', function(param, values) {\n        if (param != 'values') return;\n        vue.options = typeof(values) === 'object' ? values : values.split(',');\n      })\n\n      return {\n        value: dropdown,\n        options: values\n      }\n    },\n    watch: {\n      value: function(value) {\n        hal9.set('dropdown', value);\n      }\n    }\n  })\n\n  html.style.height = 'auto';\n</script>",
+    "11100": "<!--\n  input: []\n  params:\n    - name: label\n      label: Label\n      value:\n        - control: textbox\n          value: Number\n  output: [ html, number ]\n  layout:\n    - width: 130px\n-->\n\n<script src=\"https://cdn.jsdelivr.net/npm/vue@2\"></script>\n<link rel=\"stylesheet\" href=\"https://unpkg.com/buefy/dist/buefy.min.css\">\n<script src=\"https://unpkg.com/buefy/dist/buefy.min.js\"></script>\n\n<div class=\"control\">\n  <template>\n    <section>\n      {{ label }}\n      <b-input type=\"number\" v-model=\"value\">\n      </b-input>\n    </section>\n  </template>\n</div>\n\n<script>\n  var number = hal9.get('number');\n\n  var app = new Vue({\n    el: html.getElementsByClassName('control')[0],\n    data: function() {\n      var vue = this;\n\n      return {\n        value: number,\n        label: label\n      }\n    },\n    watch: {\n      value: function(value) {\n        hal9.set('number', value);\n      }\n    }\n  })\n\n  html.style.height = 'auto';\n</script>",
+    "11101": "/**\n  input: [ rawhtml ]\n  output: [ html ]\n  layout:\n    - width: 900px\n**/\n\nhtml.innerHTML = rawhtml;\n"
   },
   "version": "0.0.1",
   "app": {
     "stepLayouts": [
       {
         "stepId": 11099,
-        "width": "80px",
-        "left": "32px",
-        "height": "19px",
-        "top": "27px"
+        "width": "0px",
+        "left": "0px",
+        "height": "21px",
+        "top": "0px"
+      },
+      {
+        "stepId": 11100,
+        "width": "130px",
+        "left": "0px",
+        "height": "42px",
+        "top": "21px"
+      },
+      {
+        "stepId": 11101,
+        "width": "900px",
+        "left": "0px",
+        "height": "0px",
+        "top": "63px"
       }
     ]
   },
   "state": {
     "steps": {
       "11099": {
-        "events": {}
+        "events": {
+          "onParams": [
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+          ]
+        }
       }
     }
   }

--- a/examples/dropdown-table/app.R
+++ b/examples/dropdown-table/app.R
@@ -21,26 +21,3 @@ h9_node(
       as.character()
   }
 )
-library(hal9)
-
-iris |> h9_set("df")
-
-h9_node(
-  "dropdown",
-  values = c("setosa", "versicolor"),
-  on_update = function(value) {
-    h9_set(value, "selected_species")
-  }
-)
-
-h9_node(
-  "rawhtml",
-  rawhtml = function() {
-    df <- h9_get("df")
-    selected_species <- h9_get("selected_species")
-    df <- df[df$Species == selected_species, ]
-
-    knitr::kable(df, format = "html") |>
-      as.character()
-  }
-)

--- a/r/inst/client.html
+++ b/r/inst/client.html
@@ -119,7 +119,7 @@
       const environment = localhost ? 'local' : 'devel';
       const libraries = {
         local: 'http://localhost:8000/dist/hal9.js',
-        devel: 'https://cdn.jsdelivr.net/npm/hal9@0.3.13/dist/hal9.dev.js',
+        devel: 'https://cdn.jsdelivr.net/npm/hal9@0.3.16/dist/hal9.dev.js',
       }
 
       const render = async function() {

--- a/r/inst/client.html
+++ b/r/inst/client.html
@@ -114,6 +114,7 @@
       }
 
       const localhost = window.location.search.includes('localhost');
+      const debug = window.location.search.includes('debug');
 
       const environment = localhost ? 'local' : 'devel';
       const libraries = {
@@ -149,7 +150,8 @@
             /* designer events */
             onChange: onChange,
           },
-          env: environment
+          env: environment,
+          debug: debug
         }, {});
 
         pid = await hal9.load(pipeline);


### PR DESCRIPTION
Mostly, bug fixes where performed in the runtime / designer already. Just adding support for `?localhost&debug` to activate the script window to help us add breakpoints for the JS controls. Working on a more complex app with all that currently looks as follows:

<img width="823" alt="Screen Shot 2022-08-24 at 10 39 51 PM" src="https://user-images.githubusercontent.com/3478847/186536032-4d8a3e19-033c-4633-8819-ff1cb7cdaffc.png">

I'm planning to add all the controls in a single app to showcase them as a example and help us build more complex apps.
