### PR TITLE
Move package runtime js code to js library

### DIFF
--- a/r/R/hal9.R
+++ b/r/R/hal9.R
@@ -114,6 +114,10 @@ process_request <- function(req) {
 
 client_html <- function(...) {
     options <- list(...)
+    options$designer <- list(
+      persist = "pipeline",
+      eval = "eval"
+    )
 
     html <- paste(readLines(system.file("client.html", package = "hal9")), collapse = "\n")
 

--- a/r/inst/client.html
+++ b/r/inst/client.html
@@ -1,177 +1,11 @@
 <html>
   <body style="margin: 0;">
     <script>
-      var pid = undefined;
-      var manifest = {};
-
-      async function serverEval(body) {
-        console.log('Sending: \n' + JSON.stringify(body, null, 2));
-
-        const resp = await fetch('eval', {
-          method: 'POST',
-          headers: {
-            'Accept': 'application/json',
-            'Content-Type': 'application/json'
-          },
-          body: JSON.stringify(body)
-        });
-
-        const updates = await resp.json();
-
-        console.log('Receiving: \n' + JSON.stringify(updates, null, 2));
-
-        return updates;
-      }
-
-      async function serverSave(raw) {
-        await fetch('pipeline', {
-          method: 'POST',
-          headers: {
-            'Accept': 'application/json',
-            'Content-Type': 'application/json'
-          },
-          body: raw
-        });
-      }
-
-      async function performUpdates(names) {
-        if (names.length == 0) return;
-
-        const steps = await hal9.pipelines.getStepsWithHeaders(pid);
-
-        var change = {};
-        for (let name of names) change[name] = {};
-
-        const updates = await serverEval({ manifest: change });
-        for (let update of Object.keys(updates)) {
-
-          const candidates = steps.filter(e => e.name == update);
-          if (candidates.length == 0) continue;
-          const step = candidates[0];
-
-          manifest[update] = updates[update].result
-
-          await hal9.pipelines.runStep(pid, step.id, { html: 'hal9-step-' + step.id });
-        }
-      }
-
-      async function initializeManifest(pid) {
-        const steps = await hal9.pipelines.getStepsWithHeaders(pid);
-        const names = steps.map(e => e.name);
-        await performUpdates(names);
-      }
-
-      function onStart() {
-      }
-
-      function onEnd(result, steps) {
-      }
-
-      async function onChange(changes) {
-        if (changes.step !== undefined || changes.stepid !== undefined) {
-          let name = '';
-          if (changes.stepid !== undefined)
-            name = (await hal9.pipelines.getStep(pid, changes.stepid)).name;
-          else
-            name = changes.step.name;
-
-          const deps = await getForwardDependencies(changes.step.name);
-          deps.push(name);
-          await performUpdates(deps);
-        }
-      }
-
-      async function onRequestSave() {
-        const saveText = await hal9.exportto.getSaveText(pid, undefined, ['state']);
-        await serverSave(saveText);
-      }
-
-      async function getForwardDependencies(source) {
-        // TODO: Actually use the deps graph.
-        const steps = await hal9.pipelines.getStepsWithHeaders(pid);
-        const deps = steps.map(e => e.name).filter(e => e != source);
-        return deps;
-      }
-
-      async function onEvent(step, event, value) {
-        var change = {}
-        change[step.name] = {}
-        change[step.name][event] = value;
-        await serverEval({ manifest: change });
-
-        const deps = await getForwardDependencies(step.name);
-        await performUpdates(deps);
-      }
-
-      function onInvalidate(step) {
-      }
-
-      function onError(error) {
-        if (error) console.error(error);
-      }
-
-      var pipeline = {
-        "steps": [],
-        "params": {},
-        "outputs": {},
-        "scripts": {},
-        "version": "0.0.1"
-      }
-
       const localhost = window.location.search.includes('localhost');
-      const debug = window.location.search.includes('debug');
-
       const environment = localhost ? 'local' : 'devel';
       const libraries = {
         local: 'http://localhost:8000/dist/hal9.js',
-        devel: 'https://cdn.jsdelivr.net/npm/hal9@0.3.17/dist/hal9.dev.js',
-      }
-
-      const render = async function() {
-        const app = document.getElementById('output')
-        const hostopt = JSON.parse('__options__');
-
-        var resp = await fetch('/pipeline')
-        if (resp.ok) {
-          pipeline = await resp.json()
-        }
-
-        hal9 = await hal9.init({
-          iframe: true,
-          html: app,
-          api: libraries[environment],
-          editable: hostopt.mode == 'run',
-          mode: hostopt.mode,
-          pipeline: pipeline,
-          manifest: manifest,
-          events: {
-            /* pipeline events */
-            onStart: onStart,
-            onEnd: onEnd,
-            onInvalidate: onInvalidate,
-            onError: onError,
-            /* runtime events */
-            onEvent: onEvent,
-            /* designer events */
-            onChange: onChange,
-            onRequestSave: onRequestSave,
-          },
-          env: environment,
-          debug: debug
-        }, {});
-
-        pid = await hal9.load(pipeline);
-        await initializeManifest(pid);
-
-        if (hostopt.mode == 'design') {
-          await hal9.design(pid);
-        } else {
-          await hal9.run(pid, {
-            iframe: true,
-            html: 'output',
-            shadow: false
-          });
-        }
+        devel: 'https://cdn.jsdelivr.net/npm/hal9@0.3.21/dist/hal9.dev.js',
       }
 
       const script = document.createElement('script');
@@ -179,8 +13,16 @@
       script.src = libraries[environment];
       document.body.appendChild(script);
 
-      script.addEventListener('load', function() {
-        render()
+      script.addEventListener('load', async function() {
+        let hostopt = Object.assign(JSON.parse('__options__'), {
+          hostel: 'output',
+          api: libraries[environment],
+          env: environment,
+          debug: window.location.search.includes('debug')
+        });
+
+        const designer = hal9.designer(hostopt);
+        await designer.init();
       });
     </script>
     <div style="width: 100%; height: 100%">


### PR DESCRIPTION
This change moves all (most) of the JavaScript code embedded int he package into the actual JavaScript codebase. This should make it easier to debug from JavaScript as we make changes without having to rely on turning on the R / Python packages to verify or make changes. This also gets us closer to supporting a JS browser backend for those client-side apps.