### PR TITLE
return full manifest response

### DIFF
--- a/r/R/hal9.R
+++ b/r/R/hal9.R
@@ -73,7 +73,7 @@ process_request <- function(req) {
             result = list(result)
         )
     })
-    list(responses = responses)
+    list(calls = responses)
 }
 
 client_html <- function(...) {

--- a/server/src/manifest.rs
+++ b/server/src/manifest.rs
@@ -1,3 +1,4 @@
+use actix_web::rt::Runtime;
 use serde::{Deserialize, Serialize};
 
 #[derive(Deserialize, Debug, Clone)]
@@ -25,8 +26,14 @@ pub struct Arg {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct ManifestResponse {
+    pub responses: Vec<RuntimeResponse>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct RuntimeResponse {
-    pub responses: Vec<CallResponse>
+    pub calls: Vec<CallResponse>,
+    pub runtime: Option<String>
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -52,6 +52,7 @@ async fn eval(
     req: web::Json<Manifests>,
 ) -> impl Responder {
     let rt = req.manifests[0].runtime.clone();
+    let runtime = rt.clone();
     let tx_handler = &data.tx_handler;
     tx_handler.send(RtControllerMsg::GetUri(rt)).unwrap();
     let rx_uri_handler = &data.rx_uri_handler;
@@ -61,7 +62,7 @@ async fn eval(
     let client = reqwest::Client::new();
 
 
-    let res = client
+    let mut res = client
         .post(uri)
         .json(&manifest)
         .send()
@@ -70,6 +71,12 @@ async fn eval(
         .json::<RuntimeResponse>()
         .await
         .unwrap();
+    
+    res.runtime = Some(runtime);
+
+    let res = ManifestResponse {
+        responses: vec![res] 
+    };
 
     let response = serde_json::to_string(&res).unwrap();
 


### PR DESCRIPTION
server now returns full response as spec'd, e.g.
```
{
    "responses": [
        {
            "calls": [
                {
                    "node": "numberinput",
                    "fn_name": "on_update",
                    "result": [
                        "42"
                    ]
                },
                {
                    "node": "rawhtml",
                    "fn_name": "rawhtml",
                    "result": [
                        "Number (42) <br>Drodown () <br>Textbox () <br>Textarea () <br>Slider () <br>"
                    ]
                }
            ],
            "runtime": "r"
        }
    ]
}
```
only has support for 1 backend currently but will generalize when python is added next week