### PR TITLE
runtime controller python support

### DIFF
--- a/server/examples/my_app_py/hal9.toml
+++ b/server/examples/my_app_py/hal9.toml
@@ -1,0 +1,11 @@
+[application]
+name = "demo app"
+version = "0.0.1"
+
+# [client]
+# design = "client.html"
+
+[[runtimes]]
+name = "py"
+platform = "Python"
+script = "python/app.py"

--- a/server/examples/my_app_py/python/app.py
+++ b/server/examples/my_app_py/python/app.py
@@ -1,0 +1,16 @@
+import hal9 as h9
+import statsmodels.api as sm
+import pandas as pd
+
+iris = sm.datasets.get_rdataset("iris", "datasets", cache=True).data
+df = pd.DataFrame(iris)
+
+h9.set('df', df)
+
+h9.node(uid = 'dropdown', values = lambda :h9.get('df')['Species'].unique().tolist(), on_update=lambda x: h9.set('value', x))
+
+def filter_and_show_df(value):
+    df = h9.get('df')
+    return df[df['Species'] == value].to_html()
+
+h9.node('rawhtml', rawhtml = lambda :filter_and_show_df(h9.get('value')))

--- a/server/src/runtimes.rs
+++ b/server/src/runtimes.rs
@@ -158,7 +158,6 @@ impl RuntimesController {
         let py_cmd = format!("import hal9; hal9.start('{script}', {port})");
         Command::new("python3")
             .arg("-c")
-            // .arg(format!("\"{py_cmd}\""))
             .arg(format!("{py_cmd}"))
             .stderr(Stdio::piped())
             .stdout(Stdio::piped())

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -119,7 +119,7 @@ pub async fn start_server(app_path: String, port: u16) -> std::io::Result<()> {
     runtimes_controller.monitor().unwrap();
 
     tx.send(RtControllerMsg::StartAll).unwrap();
-    tx.send(RtControllerMsg::GetUri(String::from("r"))).unwrap();
+    // tx.send(RtControllerMsg::GetUri(String::from("r"))).unwrap();
 
     let tx_fs = tx.clone();
 


### PR DESCRIPTION
starting the work on python support in the server

will hold off on implementing manifest proxying until it's been fixed on the python side