### PR TITLE
allow arbitrary json in manifest args and results

### DIFF
--- a/r/R/hal9.R
+++ b/r/R/hal9.R
@@ -70,7 +70,7 @@ process_request <- function(req) {
         list(
             node = call$node,
             fn_name = fn_name,
-            result = list(result)
+            result = result
         )
     })
     list(calls = responses)

--- a/server/src/manifest.rs
+++ b/server/src/manifest.rs
@@ -21,7 +21,7 @@ pub struct Call {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Arg {
     pub name: String,
-    pub value: String,
+    pub value: Option<serde_json::Value>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -39,5 +39,5 @@ pub struct RuntimeResponse {
 pub struct CallResponse {
     pub node: String,
     pub fn_name: String,
-    pub result: Option<Vec<String>>,
+    pub result: Option<serde_json::Value>,
 }

--- a/site/manifests.qmd
+++ b/site/manifests.qmd
@@ -44,6 +44,8 @@ In this example, we're calling the `on_select()` function of the `species_dropdo
 with the value of `"setosa"` for the `value` parameter and the `html()` function of the `summary_table` node with no
 arguments.
 
+*Note that the `value` entries of `args` can be any valid JSON.*
+
 ## Computed Results
 
 Upon evaluating the manifest, the compute runtime provides a similarly specified JSON array with the function return
@@ -70,3 +72,5 @@ values. As an example, the response to the above manifest could be
     ]
 }
 ```
+
+Here, the `result` can also be arbitrary valid JSON.


### PR DESCRIPTION
also we no longer wrap the `result` from R with `list()`

closes https://github.com/hal9ai/hal9/issues/127