### PR TITLE
better errors for function calls

### DIFF
--- a/r/R/hal9.R
+++ b/r/R/hal9.R
@@ -14,7 +14,7 @@ Node <- R6::R6Class("Node", list(
         fn <- self$fns[[fn]]
 
         if (is.null(fn)) {
-            return(NULL)
+            stop("Function not defined for node.")
         }
 
         result <- NULL
@@ -74,7 +74,7 @@ process_request <- function(req) {
                 list(
                     node = call$node,
                     fn_name = fn_name,
-                    result = NULL
+                    result = list(Error = paste0("Node `", call$node, "` not defined in runtime."))
                 )
             )
         }
@@ -84,8 +84,8 @@ process_request <- function(req) {
         fn_args <- setNames(fn_args_values, fn_args_names)
 
         result <- tryCatch(
-            node$evaluate(fn_name, fn_args),
-            error = function(e) paste0(e, collapse = "\\n")
+            list(Value = node$evaluate(fn_name, fn_args)),
+            error = function(e) list(Error = paste0(e, collapse = "\\n"))
         )
 
         list(

--- a/server/src/manifest.rs
+++ b/server/src/manifest.rs
@@ -36,8 +36,14 @@ pub(crate) struct RuntimeResponse {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+pub(crate) enum FnResult {
+    Value(Option<serde_json::Value>),
+    Error(String),
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub(crate) struct CallResponse {
     pub node: String,
     pub fn_name: String,
-    pub result: Option<serde_json::Value>,
+    pub result: FnResult,
 }


### PR DESCRIPTION
closes https://github.com/hal9ai/hal9/issues/162

@javierluraschi we now return something like 
![image](https://user-images.githubusercontent.com/5582151/193997730-fab6e2a0-7847-4e98-8cbd-63a68378b40c.png)

basically for each function response we always have a `result` enum that can either be `Value` (arbitrary json, like before) or `Error` (string with error message)