### PR TITLE
Return errors optionally not nested

### DIFF
--- a/r/R/hal9.R
+++ b/r/R/hal9.R
@@ -83,16 +83,20 @@ process_request <- function(req) {
         fn_args_values <- call$args |> lapply(\(x) x$value)
         fn_args <- setNames(fn_args_values, fn_args_names)
 
-        result <- tryCatch(
-            list(Value = node$evaluate(fn_name, fn_args)),
-            error = function(e) list(Error = paste0(e, collapse = "\\n"))
-        )
-
-        list(
-            node = call$node,
-            fn_name = fn_name,
-            result = result
-        )
+        tryCatch({
+            list(
+                node = call$node,
+                fn_name = fn_name,
+                result = node$evaluate(fn_name, fn_args)
+            )
+        },
+        error = function(e) {
+            list(
+                node = call$node,
+                fn_name = fn_name,
+                error = paste0(e, collapse = "\\n")
+            )
+        })
     })
     list(calls = responses)
 }

--- a/server/src/manifest.rs
+++ b/server/src/manifest.rs
@@ -36,14 +36,9 @@ pub(crate) struct RuntimeResponse {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub(crate) enum FnResult {
-    Value(Option<serde_json::Value>),
-    Error(String),
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
 pub(crate) struct CallResponse {
     pub node: String,
     pub fn_name: String,
-    pub result: FnResult,
+    pub result: Option<serde_json::Value>,
+    pub error: Option<String>
 }


### PR DESCRIPTION
Currently manifest returns:

```
{"responses":[{"calls":[{"node":"html","fn_name":"rawhtml","result":{"Value":"Hello World!"}}],"runtime":"r"}]}
and for errors
{"responses":[{"calls":[{"node":"html","fn_name":"rawhtml","result":{"Error":"Error in fn(): Hello World!\n"}}],"runtime":"r"}]}
```

However, it would break less things to keep the manifest unchanged and also I believe is a cleaner structure to not over-nest the replies, in addition, we should use lower cases when in JSON replied. This PR change manifest to:

```
{"responses":[{"calls":[{"node":"html","fn_name":"rawhtml","result": "Hello World!"}],"runtime":"r"}]}
and
{"responses":[{"calls":[{"node":"html","fn_name":"rawhtml","error":"Error in fn(): Hello World!\n"}],"runtime":"r"}]}
```