### PR TITLE
add hal9 --version

### DIFF
--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -24,7 +24,7 @@ toml = "0.5.9"
 serde = { version = "1.0", features = ["derive"] }
 notify = {version = "5.0.0", default-features = false, features = ["macos_kqueue"] }
 tokio = { version = "1.20.1", features = ["full"] }
-clap = { version = "3.2.16", features = ["derive"] }
+clap = { version = "4.0.10", features = ["derive"] }
 crossbeam = "0.8"
 reqwest = { version = "0.11", features = ["json"] }
 serde_json = "1.0"

--- a/server/src/bin/cli.rs
+++ b/server/src/bin/cli.rs
@@ -3,6 +3,7 @@ use hal9::server::start_server;
 use hal9::app_template::new_app;
 
 #[derive(Parser)]
+#[command(author, version, about, long_about = None)]
 struct Cli {
     #[clap(subcommand)]
     command: Option<Commands>,


### PR DESCRIPTION
closes https://github.com/hal9ai/hal9/issues/184

@javierluraschi let's start at v0.1.0 and we'll increment patch version on "internal breaking changes" i.e. those that break the client or runtimes. sometime in the near future we prob want to sync everything on each commit and have tests etc instead of having to keep track of server/client versions