### PR TITLE
Move README to docs site

### DIFF
--- a/site/_quarto.yml
+++ b/site/_quarto.yml
@@ -19,13 +19,9 @@ website:
       style: "docked"
       search: true
       contents:
-        - section: "Introduction"
+        - overview.md
+        - section: "Contributing"
           contents:
-            - why.qmd
-            - roadmap.qmd
-        - section: "Developer (Advanced)"
-          contents:
-            - dev.qmd
             - config.qmd
             - manifests.qmd
 

--- a/site/overview.md
+++ b/site/overview.md
@@ -1,8 +1,8 @@
 ---
-title: "Readme"
+title: "Overview"
 ---
 
-# Hal9: Interactive data apps &mdash; design visually, power with code
+> Hal9: Interactive data apps &mdash; design visually, power with code
 
 Hal9 is a framework for building *interactive data apps* for data scientists and engineers. It allows you to utilize your DS/ML code with minimal overhead, and frees you from having to worry about frontend web frameworks. Hal9 consists of the following components:
 


### PR DESCRIPTION
The why / roadmap are already in the README, so we are just moving the README to the site. Unfortunately, it's tricky to share the README.md with the quarto site so we are just duplicating both for now.