### PR TITLE
feature gate pyo3 deps

### DIFF
--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -33,10 +33,7 @@ url = "2.2.2"
 futures = "*"
 webbrowser = "0.8.0"
 regex = "1"
-
-[dependencies.pyo3]
-version = "0.17.2"
-features = ["extension-module", "abi3-py39"]
+pyo3 = { version = "0.17.2", features = ["extension-module", "abi3-py39"], optional = true}
 
 [package.metadata.maturin]
 name = "hal9._hal9"

--- a/server/src/_hal9.rs
+++ b/server/src/_hal9.rs
@@ -1,15 +1,21 @@
+#[cfg(feature = "pyo3")]
 use pyo3::prelude::*;
 use crate::app_template::new_app;
 use crate::server::start_server;
 
+#[cfg(feature = "pyo3")]
 #[pyfunction(path = "\".\"", port = "0", timeout = "600", nobrowse = "false")]
 fn start(path: &str, port: u16, timeout: u32, nobrowse: bool){
     start_server(path.to_string(), port, timeout, nobrowse).ok();
 }
+
+#[cfg(feature = "pyo3")]
 #[pyfunction(path = "\".\"")]
 fn new(path: &str) {
     new_app(path.to_string(), crate::config::Platform::Python).ok();
 }
+
+#[cfg(feature = "pyo3")]
 #[pymodule]
 #[pyo3(name = "_hal9")]
 fn _hal9(_py: Python<'_>, m: &PyModule) -> PyResult<()> {


### PR DESCRIPTION
R package was failing to load due to something like
```
Error: package or namespace load failed for ‘hal9’ in dyn.load(file, DLLpath = DLLpath, ...):
 unable to load shared object '/Library/Frameworks/R.framework/Versions/4.2-arm64/Resources/library/00LOCK-r/00new/hal9/libs/hal9.so':
  dlopen(/Library/Frameworks/R.framework/Versions/4.2-arm64/Resources/library/00LOCK-r/00new/hal9/libs/hal9.so, 0x0006): symbol not found in flat namespace (_PyBaseObject_Type)
```

this PR makes the pyo3 deps optional which seems to fix loading on macos

for building the python package we can do `maturin build -F pyo3 -b pyo3` 