### PR TITLE
add support for matplotlib as base64 to fix #233

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -10,11 +10,19 @@ $ pip install hal9
 
 ### Source
 
+Validate Python 3.9 or newer is installed
+
+```bash
+python3 --version
+```
+
+Clone and build package as follows
+
 ```bash
 git clone https://github.com/hal9ai/hal9 && cd hal9
 pip3 install maturin
 maturin build -m python/Cargo.toml -F pyo3 -b pyo3
-pip3 install hal9 --find-links python/target/wheel
+pip3 install python/target/wheels/hal9-0.1.0-cp39-abi3-macosx_10_7_x86_64.whl --force-reinstall
 ````
 
 ## Contributing


### PR DESCRIPTION
Add support for:

```py
import hal9 as h9
import numpy as np
import matplotlib.pyplot as plt

def plot():
  arr = np.random.normal(1, 1, size=100)
  fig, ax = plt.subplots()
  ax.hist(arr, bins=200)
  return fig

h9.node("image", image = plot)
