### PR TITLE
Backend needs to make single call to modify all parameters from a step

### DIFF
--- a/client/src/core/backend/backend.js
+++ b/client/src/core/backend/backend.js
@@ -133,8 +133,10 @@ const Backend = function(hostopt) {
 
       if (call.result === null || call.result === undefined) continue;
       manifest[step.id][call['fn_name']] = call.result;
+    }
 
-      await hal9api.pipelines.runStep(pid, step.id, { html: 'hal9-step-' + step.id });
+    for (let sid of Object.keys(manifest)) {
+      await hal9api.pipelines.runStep(pid, sid, { html: 'hal9-step-' + sid });
     }
   }
 


### PR DESCRIPTION
Some controls don't update since we update first say `values` and then `value` in the say `dropdown` control, we should update all control parameters in one pass.