### PR TITLE
throw only one error in backend error

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hal9",
-  "version": "0.3.77",
+  "version": "0.3.78",
   "license": "MIT",
   "description": "Hal9: Design data apps visually, power with code",
   "main": "dist/hal9.js",

--- a/client/scripts/controls/markdown.js
+++ b/client/scripts/controls/markdown.js
@@ -4,7 +4,7 @@
     - name: markdown
       label: Markdown
       type: string
-      example: 'Hello from *Markdown*'
+      example: 'Hello **World**'
       description: A markdown string to render.
       value:
         - control: textbox
@@ -13,8 +13,8 @@
   deps:
     - https://cdnjs.cloudflare.com/ajax/libs/showdown/2.0.0/showdown.min.js
   layout:
-    - width: 600px
-      height: 450px
+    - width: 300px
+      height: 250px
   state: session
 **/
 

--- a/client/scripts/controls/rawhtml.js
+++ b/client/scripts/controls/rawhtml.js
@@ -1,4 +1,5 @@
 /**
+  input: []
   params:
     - name: rawhtml
       type: string

--- a/client/src/core/backend/backend.js
+++ b/client/src/core/backend/backend.js
@@ -326,7 +326,7 @@ const Backend = function(hostopt) {
     }
     catch (e) {
       if (hostopt.events && hostopt.events.onError) hostopt.events.onError(e.toString());
-      throw e;
+      else throw e;
     }
   }
 


### PR DESCRIPTION
Avoid throwing and raising error in backend error to avoid duplicate error messages in designer + a few control fixes for codegen.