### PR TITLE
Need to be able to update runtime changes in designer layout

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hal9",
-  "version": "0.3.78",
+  "version": "0.3.79",
   "license": "MIT",
   "description": "Hal9: Design data apps visually, power with code",
   "main": "dist/hal9.js",

--- a/client/src/core/backend/backend.js
+++ b/client/src/core/backend/backend.js
@@ -4,6 +4,8 @@ import * as server from './implementations/server';
 
 const Backend = function(hostopt) {
   let pid = undefined;
+  let pidchanged = undefined;
+
   let manifest = {};
   let hal9api = window.hal9;
   let defaultRuntime = hostopt.runtime;
@@ -269,6 +271,15 @@ const Backend = function(hostopt) {
 
   this.setpid = async function(pipelineid) {
     pid = pipelineid;
+    if (pidchanged) pidchanged(pid);
+  }
+
+  this.onpid = function(callback) {
+    pidchanged = callback;
+  }
+
+  this.getpid = function() {
+    return pid;
   }
 
   this.connect = async function(h9api) {


### PR DESCRIPTION
In order to make the designer more runtimes-centric, this PR adds support to subscribe to pipeline changes. From now on, we can change of a pipeline/designer as a kind of no-code HTML runtime that exists on a set of runtimes that an app supports.