### PR TITLE
Don't throw errors when node does not exist

### DIFF
--- a/r/R/hal9.R
+++ b/r/R/hal9.R
@@ -74,8 +74,7 @@ process_request <- function(req) {
             return(
                 list(
                     node = call$node,
-                    fn_name = fn_name,
-                    result = list(Error = paste0("Node `", call$node, "` not defined in runtime."))
+                    fn_name = fn_name
                 )
             )
         }


### PR DESCRIPTION
We can have a node defined say in JavaScript but not in R, we want this to work without errors.