### PR TITLE
Add support for basic browser terminal

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hal9",
-  "version": "0.3.79",
+  "version": "0.3.80",
   "license": "MIT",
   "description": "Hal9: Design data apps visually, power with code",
   "main": "dist/hal9.js",

--- a/client/src/core/backend/backend.js
+++ b/client/src/core/backend/backend.js
@@ -357,6 +357,20 @@ const Backend = function(hostopt) {
 
     this.onUpdated();
   }
+
+  this.initTerminal = async function(runtime) {
+    const implementation = runtimeToImplementation(runtime);
+    try {
+      if (implementations[implementation].initTerminal)
+        return await implementations[implementation].initTerminal(runtime);
+      else
+        return null;
+    }
+    catch (e) {
+      if (hostopt.events && hostopt.events.onError) hostopt.events.onError(e.toString());
+      else throw e;
+    }
+  }
 }
 
 export const backend = function(hostopt, hal9api) {


### PR DESCRIPTION
Adds support to capture `console.log`, `console.error` and `console.warn` in browser runtime to be displayed in the designer.