### PR TITLE
require minimum rust version

### DIFF
--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -2,6 +2,7 @@
 name = "hal9"
 version = "0.1.1"
 edition = "2021"
+rust-version = "1.64"
 
 [lib]
 name = "hal9"


### PR DESCRIPTION
so ppl don't get errors about features not being in stable channel, closes https://github.com/hal9ai/hal9/issues/254