### PR TITLE
Throw serialization errors from R

### DIFF
--- a/r/R/hal9.R
+++ b/r/R/hal9.R
@@ -87,10 +87,15 @@ process_request <- function(req) {
 
         tryCatch(
             {
+                result <- node$evaluate(fn_name, fn_args)
+
+                # validate we can convert to json to throw an error here and not during serialization
+                jsonlite::toJSON(result)
+
                 list(
                     node = call$node,
                     fn_name = fn_name,
-                    result = node$evaluate(fn_name, fn_args)
+                    result = result
                 )
             },
             error = function(e) {


### PR DESCRIPTION
Sometimes, errors are hidden cause R fails to serialize and we can't even detect them as errors in the Rust server. This PR forces serialization to be able to serialize serialization errors.