### PR TITLE
Reduce logs for file upload use case

### DIFF
--- a/.github/workflows/worker.yaml
+++ b/.github/workflows/worker.yaml
@@ -28,7 +28,7 @@ jobs:
         with:
           file: worker/Dockerfile
           push: true
-          tags: hal9ai/hal9-worker:latest,hal9ai/hal9-worker:0.2.8
+          tags: hal9ai/hal9-worker:latest,hal9ai/hal9-worker:0.2.9
           cache-from: type=registry,ref=user/app:latest
           cache-to: type=inline
   build:

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hal9",
-  "version": "0.3.86",
+  "version": "0.3.87",
   "license": "MIT",
   "description": "Hal9: Design data apps visually, power with code",
   "main": "dist/hal9.js",

--- a/client/src/core/backend/implementations/server.js
+++ b/client/src/core/backend/implementations/server.js
@@ -81,7 +81,7 @@ const ServerImplementation = function(hostopt) {
   }
 
   this.process = async function(body) {
-    console.log('Sending: \n' + JSON.stringify(body, null, 2));
+    console.log('Sending: \n' + JSON.stringify(body, null, 2).substr(0,512));
 
     let retries = 8;
     let resp;

--- a/r/DESCRIPTION
+++ b/r/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hal9
 Title: What the Package Does (One Line, Title Case)
-Version: 0.0.0.9001
+Version: 0.0.0.9002
 Authors@R: 
     person("First", "Last", , "first.last@example.com", role = c("aut", "cre"),
            comment = c(ORCID = "YOUR-ORCID-ID"))

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hal9"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 rust-version = "1.64"
 

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -72,7 +72,8 @@ async fn eval(
             let uri = url.join("eval").unwrap();
             let manifest = req.manifests[0].calls.clone();
 
-            println!("posting manifest {manifest:?}");
+            let manifest_str: String = serde_json::to_string(&manifest).unwrap();
+            println!("posting manifest {manifest_str:.512}");
             
             let client = reqwest::Client::new();
             
@@ -86,8 +87,8 @@ async fn eval(
 
             // let resp_msg = &res1.text().await.unwrap();
             // println!("got response {resp_msg:?}");
-            let req_json = serde_json::to_string(&manifest).unwrap();
-            println!("req json is {req_json:?}");
+            let req_json = manifest_str;
+            println!("req json is {req_json:.512}");
 
             let mut res = res1
                 .json::<RuntimeResponse>()

--- a/worker/package.json
+++ b/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hal9wrk",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "scripts": {
     "build": "rm -rf dist && webpack --mode development",
     "start": "node ./dist/server.js",

--- a/worker/src/operations/backend/init.js
+++ b/worker/src/operations/backend/init.js
@@ -32,7 +32,7 @@ function monitorSpawned(spawned, accept, reject, resolvems) {
   let stdout = '';
 
   spawned.stdout.on('data', (data) => {
-    log.info('/execute/ backend:init data: ' + data.toString());
+    log.info('/execute/ backend:init data: ' + data.toString().substr(0, 512));
   });
 
   spawned.stderr.on('data', (data) => {


### PR DESCRIPTION
When uploading files, we don't need to log everything since it makes the logs unusable.