### PR TITLE
Follow up fix for file uploader to work in python

### DIFF
--- a/.github/workflows/worker.yaml
+++ b/.github/workflows/worker.yaml
@@ -28,7 +28,7 @@ jobs:
         with:
           file: worker/Dockerfile
           push: true
-          tags: hal9ai/hal9-worker:latest,hal9ai/hal9-worker:0.2.12
+          tags: hal9ai/hal9-worker:latest,hal9ai/hal9-worker:0.2.13
           cache-from: type=registry,ref=user/app:latest
           cache-to: type=inline
   build:

--- a/python/hal9/core.py
+++ b/python/hal9/core.py
@@ -65,8 +65,9 @@ def __convert_type(obj):
         if re.match(r'^data:[a-z]+/[a-z]+;base64', obj) != None:
             contents = re.sub(r'^data:[a-z]+/[a-z]+;base64,', '', obj)
             decoded = base64.b64decode(contents)
-            temp = tempfile.NamedTemporaryFile()
+            temp = tempfile.NamedTemporaryFile(mode = "wb", delete = False)
             temp.write(decoded)
+            temp.close()
             return temp.name
         else:
             return obj

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hal9"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 rust-version = "1.64"
 

--- a/worker/package.json
+++ b/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hal9wrk",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "scripts": {
     "build": "rm -rf dist && webpack --mode development",
     "start": "node ./dist/server.js",


### PR DESCRIPTION
In Python, temp files get deleted when closed, which we need to avoid in this case.