### PR TITLE
Update core-js version in package.json to match yarn.lock (for clarity)

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -22,7 +22,7 @@
     "@babel/runtime-corejs3": "^7.19.6",
     "buffer": "^6.0.3",
     "compare-versions": "^3.6.0",
-    "core-js": "^3.23.3",
+    "core-js": "^3.26.0",
     "crypto-js": "^4.0.0",
     "indent-string": "^5.0.0",
     "js-yaml": "4.1.0",

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -1752,7 +1752,7 @@ core-js-pure@^3.25.1:
   resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.26.0.tgz#7ad8a5dd7d910756f3124374b50026e23265ca9a"
   integrity sha512-LiN6fylpVBVwT8twhhluD9TzXmZQQsr2I2eIKtWNbZI1XMfBT7CV18itaN6RA7EtQd/SDdRx/wzvAShX2HvhQA==
 
-core-js@^3.23.3:
+core-js@^3.26.0:
   version "3.26.0"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.26.0.tgz#a516db0ed0811be10eac5d94f3b8463d03faccfe"
   integrity sha512-+DkDrhoR4Y0PxDz6rurahuB+I45OsEUv8E1maPTB6OuHRohMMcznBq9TMpdpDMm/hUPob/mJJS3PqgbHpMTQgw==


### PR DESCRIPTION
My previous commit updated @babel/runtime-corejs3 version in package.json, and I had meant to update the core-js version in package.json along with it. This commit is just for clarity though, since yarn.lock was already using the new version due to the fact that yarn.lock was generated and added to the repo as part of my previous commit.