### PR TITLE
Only trigger one event for controls with events

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hal9",
-  "version": "0.3.94",
+  "version": "0.3.95",
   "license": "MIT",
   "description": "Hal9: Design data apps visually, power with code",
   "main": "dist/hal9.js",

--- a/client/src/core/api.js
+++ b/client/src/core/api.js
@@ -12,7 +12,11 @@ const RuntimeAPI = function(pipelineid, sid, context, params, input) {
     current = current ? current : {};
     current.events = current.events ? current.events : {};
     current.events[name] = current.events[name] ? current.events[name] : [];
-    current.events[name].push(callback);
+
+    // we need to add support for multiple events but can't store in state since recreating
+    // html would lead to not cleaning the callbacks
+    current.events[name] = [ callback ];
+
     pipelines.setState(pipelineid, sid, current);
   }
 


### PR DESCRIPTION
The more times a control resets the more times we subscribe to the event, which stored in the state causes us to send dozens of events to the server. This still needs to get fixed but for now support only one event.