### PR TITLE
Make textbox lazy by default to reduce requests

### DIFF
--- a/client/scripts/controls/textbox.html
+++ b/client/scripts/controls/textbox.html
@@ -31,7 +31,7 @@
   <template>
     <section>
       {{ label }}
-      <b-input type="text" v-model="value">
+      <b-input type="text" :lazy="true" v-model="value">
       </b-input>
     </section>
   </template>


### PR DESCRIPTION
Some examples like `model-with-python` run models on each keystroke which is worth avoiding, we can later make this customizable.