### PR TITLE
bump crate version

### DIFF
--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hal9"
-version = "0.1.9"
+version = "0.1.10"
 edition = "2021"
 rust-version = "1.64"
 


### PR DESCRIPTION
should bump version since we added new endpoints https://github.com/hal9ai/hal9/pull/335