### PR TITLE
Add support for events with no parameters

### DIFF
--- a/client/src/core/backend/backend.js
+++ b/client/src/core/backend/backend.js
@@ -181,6 +181,7 @@ const Backend = function(hostopt) {
 
   async function onEvent(step, event, params) {
     manifest[step.id] = manifest[step.id] ?? {};
+    params = params ?? {};
 
     var call = {
       'node': step.name,


### PR DESCRIPTION
Some events like `on_click` do not contain parameters, handle this case.