### PR TITLE
Enable content urls to enable webcams and other controls

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hal9",
-  "version": "0.3.98",
+  "version": "0.3.99",
   "license": "MIT",
   "description": "Hal9: Design data apps visually, power with code",
   "main": "dist/hal9.js",

--- a/client/src/api/iframe.js
+++ b/client/src/api/iframe.js
@@ -782,17 +782,17 @@ export const init = async (options, hal9wnd) => {
     }
 
     iframehtml = iframehtml + `\n  ${newOutputDiv} ${ scriptHeader }\n  ${ iframeScript }\n  </body></html> `
-  
-    if (options.contentsrv) {
-      var res = await fetch(options.contentsrv, {
-        method: 'POST',
-        body: JSON.stringify({ content: iframehtml }),
-        headers: { 'Content-Type': 'application/json' }
-      });
+  }
 
-      const contentdata = await res.json();
-      iframesrc = options.contentsrv + '/' + contentdata.id;
-    }
+  if (options.contentsrv) {
+    var res = await fetch(options.contentsrv, {
+      method: 'POST',
+      body: JSON.stringify({ content: iframehtml }),
+      headers: { 'Content-Type': 'application/json' }
+    });
+
+    const contentdata = await res.json();
+    iframesrc = options.contentsrv + '/' + contentdata.id;
   }
 
   if (!iframesrc) iframesrc = 'data:text/html;charset=utf-8,' + encodeURIComponent(iframehtml);


### PR DESCRIPTION
We used to create iframes with a dataurl which is convenient; however, controls like webcams or runtimes like `html` require us a proper domain, when the host specifies this capability, use it.