### PR TITLE
Add support for fast javascript backend execution

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hal9",
-  "version": "0.3.100",
+  "version": "0.3.101",
   "license": "MIT",
   "description": "Hal9: Design data apps visually, power with code",
   "main": "dist/hal9.js",

--- a/client/scripts/controls/webcam.html
+++ b/client/scripts/controls/webcam.html
@@ -35,10 +35,10 @@
     .then(function(stream) {
       video.srcObject = stream;
 
+      hal9.triggerEvent('on_image', { value: video });
       video.addEventListener('click', function() {
         if (fps == 0) {
-          hal9.triggerEvent('on_image');
-          alert('click')
+          hal9.triggerEvent('on_image', { value: video });
         }
       })
     })

--- a/client/src/api/internal.js
+++ b/client/src/api/internal.js
@@ -12,6 +12,7 @@ import * as stepapi from '../core/api';
 import * as dataframe from '../core/utils/dataframe';
 import * as workers from '../core/workers';
 import components from '../../scripts/components.json';
+import { backend } from '../core/backend/backend';
 
 export const internal = {
   remote: {
@@ -144,5 +145,20 @@ export const internal = {
 
   workers: {
     getValidWorkerUrl: workers.getValidWorkerUrl
-  }
+  },
+
+  backend: {
+    backend: backend.backend,
+    getpid: backend.getpid,
+    init: backend.init,
+    getfile: backend.getfile,
+    putFile: backend.putFile,
+    onUpdated: backend.onUpdated,
+    addRuntime: backend.addRuntime,
+    initTerminal: backend.initTerminal,
+    termRead: backend.termRead,
+    termWrite: backend.termWrite,
+    attachError: backend.attachError,
+    onpid: backend.onpid,
+  },
 }

--- a/client/src/api/native.js
+++ b/client/src/api/native.js
@@ -8,7 +8,7 @@ import * as htmloutput from '../core/htmloutput';
 import * as layout from '../core/layout';
 import * as exportto from '../core/exportto';
 import { internal } from './internal';
-import { backend } from '../core/backend/backend';
+import * as backend from '../core/backend/backend';
 
 const runRemote = async (lambda, context) => {
   if (typeof(lambda) != 'function') {

--- a/client/src/core/backend/dependencies.js
+++ b/client/src/core/backend/dependencies.js
@@ -1,5 +1,6 @@
+import * as pipelines from '../pipelines';
 
-export function Dependencies(hal9api) {
+export function Dependencies() {
   function getForwardInt(sid, steps, deps) {
     const forward = {};
     for (let dep of Object.keys(deps)) {
@@ -32,8 +33,8 @@ export function Dependencies(hal9api) {
   }
 
   this.getForward = async function(pid, sid) {
-    const steps = await hal9api.pipelines.getStepsWithHeaders(pid);
-    const deps = await hal9api.pipelines.getDependencies(pid);
+    const steps = await pipelines.getStepsWithHeaders(pid);
+    const deps = await pipelines.getDependencies(pid);
 
     return getForwardInt(sid, steps, deps);
   }
@@ -41,8 +42,8 @@ export function Dependencies(hal9api) {
   this.getInitial = async function(pid) {
     debugger;
 
-    const steps = await hal9api.pipelines.getStepsWithHeaders(pid);
-    let deps = await hal9api.pipelines.getDependencies(pid);
+    const steps = await pipelines.getStepsWithHeaders(pid);
+    let deps = await pipelines.getDependencies(pid);
 
     steps.map(step => step.id).forEach(id => {
       if (!deps[id]) deps[id] = [];

--- a/client/src/core/backend/implementations/browser.js
+++ b/client/src/core/backend/implementations/browser.js
@@ -1,5 +1,5 @@
 
-
+import { loadScripts } from '../../utils/scriptloader';
 
 const BrowserImplementation = function(hostopt) {
   var nodes = {};
@@ -137,6 +137,7 @@ ${contents}
         node: this.node,
         get: this.get,
         set: this.set,
+        require: loadScripts,
       })
     }
     finally {

--- a/client/src/core/exportto.js
+++ b/client/src/core/exportto.js
@@ -20,6 +20,7 @@ export const getSaveText = (pipelineid /*: pipelineid */, padding /*:: : number 
     'layout',
     'outputs',
     'events',
+    'context',
   ];
 
   for (var key in from) {

--- a/client/src/core/utils/scriptloader.js
+++ b/client/src/core/utils/scriptloader.js
@@ -69,6 +69,7 @@ const loadDepsForJS = async function(deps) {
 }
 
 export const loadScripts = async function(deps) {
+  if (typeof(deps) === 'string') deps = [ deps ];
   if (typeof(window) != 'undefined')
     return await loadDepsForBrowser(deps);
   else

--- a/client/src/designer/launcher.js
+++ b/client/src/designer/launcher.js
@@ -14,7 +14,7 @@ export const getDesignerLoaderHtml = (secret) => {
   `
 }
 
-export const launchDesigner = async (hal9, options, pid, backend) => {
+export const launchDesigner = async (hal9, options, pid, bid) => {
   const script = document.createElement('script');
   const libraries = {
     local: 'http://localhost:8080/hal9.notebook.js',
@@ -47,7 +47,7 @@ export const launchDesigner = async (hal9, options, pid, backend) => {
 
   await h9d.init({
     hal9: hal9,
-    backend: backend,
+    backend: bid,
     pid: pid,
     html: options.designer,
     output: options.html,


### PR DESCRIPTION
Currently backend runtimes are executed outside the iframe context; this is fine for python / r backends but for JavaScript this is not ideal for realtime applications like camera processing with `tensorflow.js`. This change moves the backend runtimes inside the iframe to allow for full-speed communication between the UX and the JS browser runtime.

This change also adds support for `h9.requires()`, as in:

```js
await h9.require([
  'https://cdn.jsdelivr.net/npm/@tensorflow/tfjs/dist/tf.min.js',
  'https://cdn.jsdelivr.net/npm/@tensorflow/tfjs-backend-webgl@3.20.0/dist/tf-backend-webgl.min.js'
])
```

To source files into the JS runtime. It also improves the webcam and image control and adds additional callback functionality from iframes.

It is likely this change will cause a few regressions that will be fixed in the next few days.