### PR TITLE
Support autogenerating several controls

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hal9",
-  "version": "0.3.101",
+  "version": "0.3.102",
   "license": "MIT",
   "description": "Hal9: Design data apps visually, power with code",
   "main": "dist/hal9.js",

--- a/client/src/core/pipelines.js
+++ b/client/src/core/pipelines.js
@@ -688,6 +688,7 @@ export const addStep = async (pipelineid /*: pipelineid */, step /*: step */) /*
 
   const scriptInfo = scripts.scriptFromStep(pipeline, step);
   step.language = scriptInfo.language;
+  step.script = scriptInfo.script;
 
   step.header = getStepHeader(pipeline, step);
 

--- a/client/src/core/scripts.js
+++ b/client/src/core/scripts.js
@@ -53,6 +53,10 @@ export const fetchScripts = async (steps /*: steps */) => {
 }
 
 export const scriptFromStep = (pipeline /* pipeline */, step /*: step */) /*: string */ => {
+  if (step.script && step.language) {
+    return { script: step.script, language: step.language };
+  }
+  
   var language = step.language;
   var text = undefined;
 


### PR DESCRIPTION
Generating controls programmatically does not work well with control names since the script gets retrieved but the name has already changed and an empty script is associated with the block.