### PR TITLE
Initialize files when runtime initialized

### DIFF
--- a/client/src/core/backend/backend.js
+++ b/client/src/core/backend/backend.js
@@ -313,6 +313,10 @@ const Backend = function(hostopt) {
     await impl.addRuntime(spec);
     runtimes[spec.name] = spec;
 
+    for (let filePath of Object.keys(spec.files)) {
+      await this.putFile(spec.name, filePath, spec.files[filePath]);
+    }
+
     await this.onUpdated();
   }
 

--- a/worker/package.json
+++ b/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hal9wrk",
-  "version": "0.2.15",
+  "version": "0.2.16",
   "scripts": {
     "build": "rm -rf dist && webpack --mode development",
     "start": "node ./dist/server.js",


### PR DESCRIPTION
We moved the backend to execute inside the iframe to increase performance of client-only applications; however, this had the side effect of running not re-running the client state until later and break initialization in `devel` environment.