### PR TITLE
Add support for async functions in js nodes

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hal9",
-  "version": "0.3.105",
+  "version": "0.3.106",
   "license": "MIT",
   "description": "Hal9: Design data apps visually, power with code",
   "main": "dist/hal9.js",

--- a/client/src/core/backend/implementations/browser.js
+++ b/client/src/core/backend/implementations/browser.js
@@ -21,7 +21,7 @@ const BrowserImplementation = function(hostopt) {
         throw 'The property "' + name + '" in "' + uid + '" is not a function';
     }
 
-    this.evaluate = function(fn, args) {
+    this.evaluate = async function(fn, args) {
       if (!self.functions[fn]) return undefined;
       if (typeof(self.functions[fn]) !== 'function') return self.functions[fn];
 
@@ -30,7 +30,7 @@ const BrowserImplementation = function(hostopt) {
       for (let arg of args)
         flat.push(arg.value);
       
-      return self.functions[fn].apply(this, flat || []);
+      return await self.functions[fn].apply(this, flat || []);
     }
   }
 
@@ -94,7 +94,7 @@ const BrowserImplementation = function(hostopt) {
           results.push({
             'node': uid,
             'fn_name': functionName,
-            'result': node.evaluate(functionName, args)
+            'result': await node.evaluate(functionName, args)
           });
         }
       }


### PR DESCRIPTION
This code works:

```js
h9.node("html", {
  rawhtml: () => h9.get("button")
});
```

This code doesn't

```js
h9.node("html", {
  rawhtml: async () => h9.get("button")
});
```

This was tricky to debug cause you get an object which is no longer a promise which made it seem like callbacks were broken, but they are not.