### PR TITLE
Add support for JavaScript charts

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hal9",
-  "version": "0.3.106",
+  "version": "0.3.107",
   "license": "MIT",
   "description": "Hal9: Design data apps visually, power with code",
   "main": "dist/hal9.js",

--- a/client/scripts/controls/chart.html
+++ b/client/scripts/controls/chart.html
@@ -22,15 +22,24 @@
     - width: 200px
       height: 200px
   state: session
+  interactive: true
 -->
 
-<div>
+<div class="chartContainer" style="width: 100%; height: 100%;">
   <img class="imageContainer">
 </div>
 
 <script>
-  let el = html.getElementsByClassName('imageContainer')[0];
-
-  el.src = chart;
-  el.style.width = '100%';
+  hal9.onEvent('param', function(param, value) {
+    if (param != 'chart' || value == '') return;
+    if (typeof(value) === 'object') {
+      let el = html.getElementsByClassName('chartContainer')[0];
+      el.append(value)
+    }
+    else {
+      let el = html.getElementsByClassName('imageContainer')[0];
+      el.src = value;
+      el.style.width = '100%';
+    }
+  })
 </script>

--- a/client/src/core/layout.js
+++ b/client/src/core/layout.js
@@ -94,7 +94,7 @@ export const prepareForDocumentView = (pipeline, context, stepstopid) => {
       if (window.hal9.layouts[pipeline.id] === layoutHTML) {
         const stepEls = html.querySelectorAll(':scope .hal9-step');
         [...stepEls].map(el => {
-          if (el.classList.contains('hal9-interactive') && (context.siteMode !== 'layout')) {
+          if (el.classList.contains('hal9-interactive')) {
             // interactive elements are not erased but rather handle interactions themselves
           }
           else {
@@ -130,7 +130,7 @@ export const prepareForDocumentView = (pipeline, context, stepstopid) => {
       if (!output) output = html.querySelector('.hal9-step-' + step.id);
 
       const interactiveClass = header.interactive ? ' hal9-interactive' : '';
-      if (isFullView && output && !(output.classList.contains('hal9-interactive') && (context.siteMode !== 'layout'))) {
+      if (isFullView && output && !(output.classList.contains('hal9-interactive'))) {
         output.innerHTML = '';
       }
 

--- a/client/src/core/pipelines.js
+++ b/client/src/core/pipelines.js
@@ -263,7 +263,7 @@ export const runStep = async (pipelineid /*: pipeline */, sid /*: number */, con
     if (context.params || context.manifest) {
       context.params = context.params ?? {};
       if (context.manifest && context.manifest[sid]) {
-        context.params = clone(context.manifest[sid])
+        context.params = context.manifest[sid];
       }
 
       var paramIdx = Object.keys(params).length > 0 ? Math.max(...Object.keys(params).map(e => params[e].id ? params[e].id : 0)) : 0;
@@ -279,7 +279,7 @@ export const runStep = async (pipelineid /*: pipeline */, sid /*: number */, con
 
           params[param] = {
             id: paramIdx++, name: param, label: param, value: [{
-              value: clone(context.params[param])
+              value: context.params[param]
             }]
           };
           delete context.params[param];


### PR DESCRIPTION
Enables adding JavaScript chart powered by various libraries, like Observable Plot

<img width="1431" alt="Screen Shot 2022-11-15 at 11 31 12 PM" src="https://user-images.githubusercontent.com/3478847/202084121-4e6adb14-3da7-44b4-a6cd-a20fb7498a8a.png">

```js

let ui = {};

await h9.require([
  'https://cdn.jsdelivr.net/npm/d3@7',
  'https://cdn.jsdelivr.net/npm/@observablehq/plot@0.6'
]);

h9.node("chart", {
  chart: () => {
    const data = [ { 'x': 'a', 'y': 1 }, { 'x': 'b', 'y': 3 } ];

    return Plot.plot({
      y: { grid: true },
      marks: [ Plot.barY(data, {x: 'x', y: 'y', fill: "#528efd"}) ]
    });


  }
});
```

Reverts https://github.com/hal9ai/hal9/commit/499581593347c6264148dd865453db625d007b10, otherwise resizing causes us to clear the chart and we have no way of redrawing it.

Removes a few `clone()` entries in the manifest to persist the DOMElement which is not clonable.