### PR TITLE
Context is not serializable due to events affecting HTML runtime

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hal9",
-  "version": "0.3.107",
+  "version": "0.3.108",
   "license": "MIT",
   "description": "Hal9: Design data apps visually, power with code",
   "main": "dist/hal9.js",


### PR DESCRIPTION
Problem: Add a python runtime, add an html runtime, edit html runtime. Edit fails.
Cause: The HTML block requires events stored in the context which is not serializable due to callbacks, this was a problem introduced when we moved the backend to be inside the iframe which we needed to support proper javascript communication.

Context is not serializable due to events and does not need to be part of pipeline.