### PR TITLE
Process scripts to enable rendering plotly charts to fix #372

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hal9",
-  "version": "0.3.108",
+  "version": "0.3.109",
   "license": "MIT",
   "description": "Hal9: Design data apps visually, power with code",
   "main": "dist/hal9.js",

--- a/client/scripts/controls/rawhtml.js
+++ b/client/scripts/controls/rawhtml.js
@@ -11,6 +11,76 @@
     - width: 200px
       height: 200px
   state: session
+  interactive: true
 **/
 
-html.innerHTML = rawhtml;
+async function fixScripts() {
+  const scripts = [...html.getElementsByTagName('script')];
+
+  var hasUnknownType = false;
+  for (var idx in scripts) {
+    const script = scripts[idx];
+
+    var tag = document.createElement("script");
+
+    script.getAttributeNames().forEach(function(name) {
+      if (name != 'id') tag.setAttribute(name, script.getAttribute(name));
+    });
+
+    if (script.src || script.type == 'module') {
+      if (script.type == 'module')
+        tag.innerHTML = script.innerHTML + ';hal9HtmlScriptLoaded();';
+      else
+        tag.src = script.src;
+
+      script.remove();
+
+      if (!window.hal9htmlscripts) window.hal9htmlscripts = {};
+      if (script.src && window.hal9htmlscripts[script.src] === 'loaded') continue;
+      
+      const loaded = new Promise((resolve, reject) => {
+        const errorHandler = function(e) {
+          window.removeEventListener('error', errorHandler);
+          reject('HTML Failed to load ' + e.srcElement.src + (e.message ? ': ' + e.message : ''));
+        }
+
+        const loadHandler = function() {
+          window.removeEventListener('error', errorHandler);
+          if (script.src) window.hal9scripts[script.src] = 'loaded'
+          resolve();
+        }
+
+        window.addEventListener('error', errorHandler);
+        window.hal9HtmlScriptLoaded = loadHandler;
+
+        tag.addEventListener('load', loadHandler);
+        tag.addEventListener('error', errorHandler);
+        tag.addEventListener('abort', errorHandler);   
+      });
+
+      htmlref.appendChild(tag);
+
+      await loaded;
+    }
+    else if (!script.type || script.type == 'text/javascript' || script.type == 'text/jsx' || script.type == 'text/jsx' || script.type == 'text/babel') {
+      var code = script.innerHTML;
+
+      if (script.type == 'text/jsx' || script.type == 'text/babel')
+        code = Babel.transform(code, { presets: ['env', 'react'] }).code;
+
+      const fn = new Function([], code);
+
+      await fn(...Object.values(_hal9_params));
+    }
+    else {
+      throw('Unsupported script type in HTML')
+    }
+  }
+}
+
+hal9.onEvent('param', async function(param, value) {
+  if (!value || param != 'rawhtml') return;
+  
+  html.innerHTML = value;
+  await fixScripts()
+})


### PR DESCRIPTION
Python generates plotly charts with `<script></script>` tags we need to process for the app to render properly.