### PR TITLE
Do not delete manifest data to persist over runs to fix #373

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hal9",
-  "version": "0.3.109",
+  "version": "0.3.110",
   "license": "MIT",
   "description": "Hal9: Design data apps visually, power with code",
   "main": "dist/hal9.js",

--- a/client/src/core/pipelines.js
+++ b/client/src/core/pipelines.js
@@ -263,8 +263,11 @@ export const runStep = async (pipelineid /*: pipeline */, sid /*: number */, con
 
     if (context.params || context.manifest) {
       context.params = context.params ?? {};
+
+      let deleteParams = true;
       if (context.manifest && context.manifest[sid]) {
         context.params = context.manifest[sid];
+        deleteParams = false;
       }
 
       var paramIdx = Object.keys(params).length > 0 ? Math.max(...Object.keys(params).map(e => params[e].id ? params[e].id : 0)) : 0;
@@ -273,7 +276,7 @@ export const runStep = async (pipelineid /*: pipeline */, sid /*: number */, con
           console.log('Param ' + param + ' of type ' + typeof(input[param]) + ' matched with input in step ' + step.name + '/' + step.id)
 
           input[param] = clone(context.params[param]);
-          delete context.params[param];
+          if (deleteParams) delete context.params[param];
         }
         else if (Object.keys(params).includes(param)) {
           console.log('Param ' + param + ' of type ' + typeof(params[param]) + ' matched with param in step ' + step.name + '/' + step.id)
@@ -283,7 +286,7 @@ export const runStep = async (pipelineid /*: pipeline */, sid /*: number */, con
               value: context.params[param]
             }]
           };
-          delete context.params[param];
+          if (deleteParams) delete context.params[param];
         }
       });
     }


### PR DESCRIPTION
The manifest functionality was meant to allow re-running client state even when the server not available, no need to remove params which was design to run apis, etc.