### PR TITLE
Fix regression in html control with zero values

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hal9",
-  "version": "0.3.110",
+  "version": "0.3.111",
   "license": "MIT",
   "description": "Hal9: Design data apps visually, power with code",
   "main": "dist/hal9.js",

--- a/client/scripts/controls/rawhtml.js
+++ b/client/scripts/controls/rawhtml.js
@@ -79,7 +79,7 @@ async function fixScripts() {
 }
 
 hal9.onEvent('param', async function(param, value) {
-  if (!value || param != 'rawhtml') return;
+  if (value === null || param != 'rawhtml') return;
   
   html.innerHTML = value;
   await fixScripts()


### PR DESCRIPTION
Following code not working due to incorrect check:

```py

import hal9 as h9

h9.set("length", 0)

def updated(value):
  h9.set("length", value.length)

h9.textarea("textarea", on_update=updated)

h9.html("html", rawhtml=lambda: h9.get("length"))
```