### PR TITLE
Follow up to 72cb56b which does not support interactivity

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hal9",
-  "version": "0.3.115",
+  "version": "0.3.116",
   "license": "MIT",
   "description": "Hal9: Design data apps visually, power with code",
   "main": "dist/hal9.js",

--- a/client/src/core/backend/backend.js
+++ b/client/src/core/backend/backend.js
@@ -142,7 +142,8 @@ const Backend = function(hostopt) {
     for (let sid of Object.keys(stepManifest)) {
       await pipelines.runStep(pid, sid, {
         manifest: stepManifest,
-        html: 'hal9-step-' + sid
+        html: 'hal9-step-' + sid,
+        root: hostopt.context ? hostopt.context.root : undefined,
       });
     }
   }

--- a/client/src/core/executors/local.js
+++ b/client/src/core/executors/local.js
@@ -5,13 +5,19 @@ import * as interpreter from '../interpreters/interpreter';
 
 import clone from '../utils/clone';
 
-function getHtmlForLocal(html, step) {
-  if (typeof(html) == 'function')
-    return html(step);
-  else if (typeof(html) == 'string')
-    return document.getElementsByClassName(html)[0];
+function getHtmlForLocal(context, step) {
+  if (typeof(context.html) == 'function')
+    return context.html(step);
+  else if (typeof(context.html) == 'string') {
+    if (context.root) {
+      return context.root.querySelectorAll('.' + context.html)[0]
+    }
+    else {
+      return document.getElementsByClassName(context.html)[0];
+    }
+  }
   else
-    return html;
+    return context.html;
 }
 
 export default class LocalExecutor extends Executor {
@@ -19,7 +25,7 @@ export default class LocalExecutor extends Executor {
     var params = localparams.paramsForFunction(this.params, this.inputs, this.deps);
 
     // add html to params
-    params['html'] = getHtmlForLocal(this.context['html'], this.step);
+    params['html'] = getHtmlForLocal(this.context, this.step);
     if (this.deps && this.deps.hal9) this.deps.hal9.setHtml(params['html']);
 
     // retrieve cached hal9 datasets

--- a/client/src/core/layout.js
+++ b/client/src/core/layout.js
@@ -84,6 +84,7 @@ export const prepareForDocumentView = (pipeline, context, stepstopid) => {
       
     const height = parent.offsetHeight;
     const html = parent.shadowRoot ? parent.shadowRoot : (context.shadow === false ? parent : parent.attachShadow({ mode: 'open' }));
+    context.root = html;
 
     const isFullView = stepstopid === null || stepstopid === undefined;
     const layoutHTML = getForDocumentView(pipeline);

--- a/client/src/core/pipelines.js
+++ b/client/src/core/pipelines.js
@@ -519,7 +519,8 @@ export const run = async (pipelineid /*: pipelineid */, context /* context */, p
         onError: function(e) {
           console.error(e);
         }
-      }
+      },
+      context: context
     });
     await backend.init(backendObject, pipelineid);
     const runtimes = await getRuntimeSpecs(pipelineid);


### PR DESCRIPTION
Fix to support embedding with 72cb56b missed to add support for interactivity. By default it creates a ShadowDOM environment, but during execution it was querying the global document environment which has no access to the shadow root.

Fix here is to remember the shadow root and pass the context to the backend such that calls to `runStep()` which execute in the `LocalExecutor` end up searching inside the shadow root.